### PR TITLE
chore: make the `channelElements` private

### DIFF
--- a/src/feed.ts
+++ b/src/feed.ts
@@ -19,7 +19,7 @@ export class Feed implements RSS {
    * transformation (if necessary) will be handled externally or in future
    * enhancements.
    */
-  readonly channelElements: ChannelElements;
+  private readonly channelElements: ChannelElements;
 
   /**
    * Creates a new `RSS` feed instance with the provided channel metadata.

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,13 +213,6 @@ export interface ChannelElements {
  */
 export interface RSS {
   /**
-   * Metadata describing the RSS `<channel>` element inclluding required fields
-   * such as title, link and description along with optional publishing and
-   * presentation attributes.
-   */
-  readonly channelElements: ChannelElements;
-
-  /**
    * Generates the RSS feed as a serialised XML string.
    *
    * @returns A serialised RSS 2.0 XML document as a UTF-8 string.


### PR DESCRIPTION
## Description

This PR removes a public `channelElement` from the public `RSS` interface. Doing so allows the implementation of the `RSS` interface (the `Feed` class in this context) to make its `channelElements` private and inaccessible to the public.

The minor improvement should make usage of the code much simpler and easier to use.

## Type of Change

Select the type of change this PR introduces:

- [ ] Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation Update
- [ ] Other (please describe below)

## How Has This Been Tested?

Describe the testing strategy and steps taken to verify your changes.